### PR TITLE
Pagination Implementation

### DIFF
--- a/src/account/AccountAPI.test.ts
+++ b/src/account/AccountAPI.test.ts
@@ -50,7 +50,7 @@ describe('AccountAPI', () => {
     it('lists the account activity', async () => {
       const accounts = await global.client.rest.account.listAccounts();
       const accountId = accounts[0].id;
-      const history = await global.client.rest.account.getAccountHistory(accountId);
+      const history = await global.client.rest.account.getAccountHistory(accountId, {limit: 100});
       expect(history).toBeDefined();
     });
   });

--- a/src/account/AccountAPI.ts
+++ b/src/account/AccountAPI.ts
@@ -1,6 +1,5 @@
 import {AxiosInstance} from 'axios';
-import {Pagination, PAGINATION_LIMIT} from '../payload/common';
-import {RESTData} from '..';
+import {Pagination} from '../payload/common';
 
 export interface Account {
   available: string;
@@ -63,7 +62,10 @@ export class AccountAPI {
    * @param pagination - Pagination field
    * @see https://docs.pro.coinbase.com/#get-account-history
    */
-  async getAccountHistory(accountId: string, pagination: Pagination): Promise<RESTData> {
+  async getAccountHistory(
+    accountId: string,
+    pagination?: Pagination
+  ): Promise<{data: AccountHistory[]; pagination: {after?: string; before?: string}}> {
     const resource = `${AccountAPI.URL.ACCOUNTS}/${accountId}/ledger`;
     const response = await this.apiClient.get<AccountHistory[]>(resource, {params: pagination});
     return {
@@ -71,7 +73,6 @@ export class AccountAPI {
       pagination: {
         after: response.headers['cb-after'],
         before: response.headers['cb-before'],
-        limit: pagination?.limit ? pagination.limit : PAGINATION_LIMIT,
       },
     };
   }
@@ -82,12 +83,22 @@ export class AccountAPI {
    * canceled, any remaining hold is removed. For a withdraw, once it is completed, the hold is removed.
    *
    * @param accountId - Account ID belonging to the API key’s profile
+   * @param pagination
    * @see https://docs.pro.coinbase.com/#get-holds
    */
-  async getHolds(accountId: string): Promise<Hold[]> {
+  async getHolds(
+    accountId: string,
+    pagination?: Pagination
+  ): Promise<{data: Hold[]; pagination: {after?: string; before?: string}}> {
     const resource = `${AccountAPI.URL.ACCOUNTS}/${accountId}/holds`;
-    const response = await this.apiClient.get<Hold[]>(resource);
-    return response.data;
+    const response = await this.apiClient.get<Hold[]>(resource, {params: pagination});
+    return {
+      data: response.data,
+      pagination: {
+        after: response.headers['cb-after'],
+        before: response.headers['cb-before'],
+      },
+    };
   }
 
   /**

--- a/src/account/AccountAPI.ts
+++ b/src/account/AccountAPI.ts
@@ -1,4 +1,6 @@
 import {AxiosInstance} from 'axios';
+import {Pagination, PAGINATION_LIMIT} from '../payload/common';
+import {RESTData} from '..';
 
 export interface Account {
   available: string;
@@ -58,12 +60,20 @@ export class AccountAPI {
    * balance. Items are paginated and sorted latest first.
    *
    * @param accountId - Account ID belonging to the API key’s profile
+   * @param pagination - Pagination field
    * @see https://docs.pro.coinbase.com/#get-account-history
    */
-  async getAccountHistory(accountId: string): Promise<AccountHistory[]> {
+  async getAccountHistory(accountId: string, pagination: Pagination): Promise<RESTData> {
     const resource = `${AccountAPI.URL.ACCOUNTS}/${accountId}/ledger`;
-    const response = await this.apiClient.get<AccountHistory[]>(resource);
-    return response.data;
+    const response = await this.apiClient.get<AccountHistory[]>(resource, {params: pagination});
+    return {
+      data: response.data,
+      pagination: {
+        after: response.headers['cb-after'],
+        before: response.headers['cb-before'],
+        limit: pagination?.limit ? pagination.limit : PAGINATION_LIMIT,
+      },
+    };
   }
 
   /**

--- a/src/client/RESTClient.ts
+++ b/src/client/RESTClient.ts
@@ -14,12 +14,6 @@ import axiosRetry, {isNetworkOrIdempotentRequestError} from 'axios-retry';
 import util from 'util';
 import {EventEmitter} from 'events';
 import {getErrorMessage, gotRateLimited, inAirPlaneMode} from '../error/ErrorUtil';
-import {Pagination} from '..';
-
-export interface RESTData {
-  data: any;
-  pagination: Pagination
-}
 
 export interface RESTClient {
   on(

--- a/src/client/RESTClient.ts
+++ b/src/client/RESTClient.ts
@@ -14,6 +14,12 @@ import axiosRetry, {isNetworkOrIdempotentRequestError} from 'axios-retry';
 import util from 'util';
 import {EventEmitter} from 'events';
 import {getErrorMessage, gotRateLimited, inAirPlaneMode} from '../error/ErrorUtil';
+import {Pagination} from '..';
+
+export interface RESTData {
+  data: any;
+  pagination: Pagination
+}
 
 export interface RESTClient {
   on(

--- a/src/fill/FillAPI.test.ts
+++ b/src/fill/FillAPI.test.ts
@@ -31,14 +31,14 @@ describe('FillAPI', () => {
   describe('getFillsByOrderId', () => {
     it('filters filled orders by order ID', async () => {
       const filledOrders = await global.client.rest.fill.getFillsByOrderId('0e8029ae-ba75-4e3a-9472-efc8183005c4');
-      expect(filledOrders[0].trade_id).toBe(2522525);
+      expect(filledOrders.data[0].trade_id).toBe(2522525);
     });
   });
 
   describe('getFillsByProductId', () => {
     it('filters filled orders by product ID', async () => {
       const filledOrders = await global.client.rest.fill.getFillsByProductId('BTC-EUR');
-      expect(filledOrders.length).toBe(2);
+      expect(filledOrders.data.length).toBe(2);
     });
   });
 });

--- a/src/fill/FillAPI.ts
+++ b/src/fill/FillAPI.ts
@@ -1,5 +1,5 @@
 import {AxiosInstance} from 'axios';
-import {ISO_8601_MS_UTC, UUID_V4, OrderSide} from '../payload/common';
+import {ISO_8601_MS_UTC, UUID_V4, OrderSide, Pagination} from '../payload/common';
 
 export enum Liquidity {
   MAKER = 'M',
@@ -29,23 +29,48 @@ export class FillAPI {
 
   constructor(private readonly apiClient: AxiosInstance) {}
 
-  // https://docs.pro.coinbase.com/#list-fills
-  // https://pro.coinbase.com/orders/filled
-  async getFillsByOrderId(orderId: string): Promise<Fill[]> {
+  /**
+   * Get a list of recent fills for a given Order of the API key's profile.
+   * @param orderId
+   * @param pagination
+   * @see https://docs.pro.coinbase.com/#list-fills
+   * @see https://pro.coinbase.com/orders/filled
+   */
+  async getFillsByOrderId(
+    orderId: string,
+    pagination?: Pagination
+  ): Promise<{data: Fill[]; pagination: {after?: string; before?: string}}> {
     const resource = FillAPI.URL.FILLS;
-    const response = await this.apiClient.get(resource, {params: {order_id: orderId}});
-    return response.data;
+    const response = await this.apiClient.get(resource, {params: {order_id: orderId, ...pagination}});
+    return {
+      data: response.data,
+      pagination: {
+        after: response.headers['cb-after'],
+        before: response.headers['cb-before'],
+      },
+    };
   }
 
-  // https://docs.pro.coinbase.com/#list-fills
-  // https://pro.coinbase.com/orders/filled
-  /* TODO: Implement "CB-BEFORE" header:
-   * The CB-BEFORE header will have this first trade id so that future requests using the cb-before parameter will
-   * fetch fills with a greater trade id (newer fills)
+  /**
+   * Get a list of recent fills for a given Product of the API key's profile.
+   *
+   * @param productId
+   * @param pagination
+   * @see https://docs.pro.coinbase.com/#list-fills
+   * @see https://pro.coinbase.com/orders/filled
    */
-  async getFillsByProductId(productId: string): Promise<Fill[]> {
+  async getFillsByProductId(
+    productId: string,
+    pagination?: Pagination
+  ): Promise<{data: Fill[]; pagination: {after?: string; before?: string}}> {
     const resource = FillAPI.URL.FILLS;
-    const response = await this.apiClient.get(resource, {params: {product_id: productId}});
-    return response.data;
+    const response = await this.apiClient.get(resource, {params: {product_id: productId, ...pagination}});
+    return {
+      data: response.data,
+      pagination: {
+        after: response.headers['cb-after'],
+        before: response.headers['cb-before'],
+      },
+    };
   }
 }

--- a/src/order/OrderAPI.test.ts
+++ b/src/order/OrderAPI.test.ts
@@ -75,8 +75,8 @@ describe('OrderAPI', () => {
 
       const openOrders = await global.client.rest.order.getOpenOrders();
 
-      expect(openOrders.length).toBe(1);
-      expect(openOrders[0].status).toBe(OrderStatus.OPEN);
+      expect(openOrders.data.length).toBe(1);
+      expect(openOrders.data[0].status).toBe(OrderStatus.OPEN);
     });
   });
 

--- a/src/order/OrderAPI.ts
+++ b/src/order/OrderAPI.ts
@@ -1,5 +1,5 @@
 import {AxiosInstance} from 'axios';
-import {OrderSide} from '../payload/common';
+import {OrderSide, Pagination} from '../payload/common';
 
 export enum OrderType {
   LIMIT = 'limit',
@@ -73,14 +73,34 @@ export class OrderAPI {
     return response.data;
   }
 
-  // https://docs.pro.coinbase.com/#list-orders
-  async getOpenOrders(): Promise<Order[]> {
+  /**
+   * List your current open orders from the profile that the API key belongs to. Only open or un-settled
+   * orders are returned. As soon as an order is no longer open and settled, it will no longer appear
+   * in the default request.
+   *
+   * @param pagination
+   * @see https://docs.pro.coinbase.com/#list-orders
+   */
+  async getOpenOrders(
+    pagination?: Pagination
+  ): Promise<{data: Order[]; pagination: {after?: string; before?: string}}> {
     const resource = OrderAPI.URL.ORDERS;
-    const response = await this.apiClient.get(resource);
-    return response.data;
+    const response = await this.apiClient.get(resource, {params: pagination});
+    return {
+      data: response.data,
+      pagination: {
+        after: response.headers['cb-after'],
+        before: response.headers['cb-before'],
+      },
+    };
   }
 
-  // https://docs.pro.coinbase.com/#get-an-order
+  /**
+   * Get a single order by order id from the profile that the API key belongs to.
+   *
+   * @param orderId
+   * @see https://docs.pro.coinbase.com/#get-an-order
+   */
   async getOrder(orderId: string): Promise<Order | null> {
     const resource = `${OrderAPI.URL.ORDERS}/${orderId}`;
     try {

--- a/src/payload/common.ts
+++ b/src/payload/common.ts
@@ -4,9 +4,6 @@ export type ISO_8601_MS_UTC = string;
 /** UUID, both forms (with and without dashes) are accepted, i.e. "132fb6ae-456b-4654-b4e0-d681ac05cea1" or "132fb6ae456b4654b4e0d681ac05cea1" */
 export type UUID_V4 = string;
 
-/** Pagination Limit **/
-export const PAGINATION_LIMIT = 100;
-
 export enum OrderSide {
   BUY = 'buy',
   SELL = 'sell',
@@ -15,5 +12,5 @@ export enum OrderSide {
 export interface Pagination {
   before?: string;
   after?: string;
-  limit?: number;
+  limit: number;
 }

--- a/src/payload/common.ts
+++ b/src/payload/common.ts
@@ -4,7 +4,16 @@ export type ISO_8601_MS_UTC = string;
 /** UUID, both forms (with and without dashes) are accepted, i.e. "132fb6ae-456b-4654-b4e0-d681ac05cea1" or "132fb6ae456b4654b4e0d681ac05cea1" */
 export type UUID_V4 = string;
 
+/** Pagination Limit **/
+export const PAGINATION_LIMIT = 100;
+
 export enum OrderSide {
   BUY = 'buy',
   SELL = 'sell',
+}
+
+export interface Pagination {
+  before?: string;
+  after?: string;
+  limit?: number;
 }

--- a/src/payload/common.ts
+++ b/src/payload/common.ts
@@ -4,6 +4,9 @@ export type ISO_8601_MS_UTC = string;
 /** UUID, both forms (with and without dashes) are accepted, i.e. "132fb6ae-456b-4654-b4e0-d681ac05cea1" or "132fb6ae456b4654b4e0d681ac05cea1" */
 export type UUID_V4 = string;
 
+/** Maximum Pagination Limit **/
+export const MAXIMUM_PAGINATION_LIMIT = 100;
+
 export enum OrderSide {
   BUY = 'buy',
   SELL = 'sell',

--- a/src/product/ProductAPI.test.ts
+++ b/src/product/ProductAPI.test.ts
@@ -74,7 +74,7 @@ describe('ProductAPI', () => {
         .get(`${ProductAPI.URL.PRODUCTS}/${productId}/trades`)
         .reply(200, JSON.stringify(TradesBTCEUR));
       const trades = await global.client.rest.product.getTrades(productId);
-      expect(trades.length).toBe(100);
+      expect(trades.data.length).toBe(100);
     });
   });
 

--- a/src/product/ProductAPI.ts
+++ b/src/product/ProductAPI.ts
@@ -1,5 +1,5 @@
 import {AxiosInstance, AxiosResponse} from 'axios';
-import {ISO_8601_MS_UTC, OrderSide} from '../payload/common';
+import {ISO_8601_MS_UTC, OrderSide, Pagination} from '../payload/common';
 import {CandleBucketUtil} from './CandleBucketUtil';
 import {RESTClient} from '..';
 
@@ -274,11 +274,21 @@ export class ProductAPI {
    * Get latest trades for a product.
    *
    * @param productId - Representation for base and counter
+   * @param pagination
    */
-  async getTrades(productId: string): Promise<Trade[]> {
+  async getTrades(
+    productId: string,
+    pagination?: Pagination
+  ): Promise<{data: Trade[]; pagination: {after?: string; before?: string}}> {
     const resource = `${ProductAPI.URL.PRODUCTS}/${productId}/trades`;
-    const response = await this.apiClient.get<Trade[]>(resource);
-    return response.data;
+    const response = await this.apiClient.get<Trade[]>(resource, {params: pagination});
+    return {
+      data: response.data,
+      pagination: {
+        after: response.headers['cb-after'],
+        before: response.headers['cb-before'],
+      },
+    };
   }
 
   /**


### PR DESCRIPTION
This is a basic pagination implementation, I'll be more than glad to implement the full pagination just wanted to better discuss code design to be sure that this follows the idea that @bennyn had.

The actual implementation implies a big change in the way the callback results are handled since it will devide them in two sections:
- **data** : Returns the actual data (unmodified)
- **pagination** : Returns 3 settings `limit`, `after` and `before`

Everything remains the same naming as in the officiel API doc https://docs.pro.coinbase.com/#pagination