### PR TITLE
add ability to cancel a single order using the order id

### DIFF
--- a/src/order/OrderAPI.test.ts
+++ b/src/order/OrderAPI.test.ts
@@ -133,6 +133,18 @@ describe('OrderAPI', () => {
     });
   });
 
+  describe('cancelOrder', () => {
+    it('correctly deletes order', async () => {
+      nock(global.REST_URL)
+        .delete(`${OrderAPI.URL.ORDERS}/8eba9e7b-08d6-4667-90ca-6db445d743c1`)
+        .query(true)
+        .reply(200, '8eba9e7b-08d6-4667-90ca-6db445d743c1');
+
+      const canceledOrderId = await global.client.rest.order.cancelOrder('8eba9e7b-08d6-4667-90ca-6db445d743c1');
+      expect(canceledOrderId).toEqual('8eba9e7b-08d6-4667-90ca-6db445d743c1');
+    });
+  });
+
   describe('cancelOpenOrders', () => {
     it('correctly deletes all open orders if no productId is passed', async () => {
       nock(global.REST_URL)

--- a/src/order/OrderAPI.ts
+++ b/src/order/OrderAPI.ts
@@ -104,8 +104,8 @@ export class OrderAPI {
   constructor(private readonly apiClient: AxiosInstance) {}
 
   /**
-   * Cancel a previously placed order. Order must belong to the profile that the API key belongs to. If no product is
-   * specified, all open orders from the profile that the API key belongs to will be canceled.
+   * With best effort, cancel all open orders from the profile that the API key belongs to.
+   * The response is a list of ids of the canceled orders.
    *
    * @param productId - Representation for base and counter
    * @returns A list of ids of the canceled orders
@@ -116,6 +116,18 @@ export class OrderAPI {
     const response = await this.apiClient.delete(resource, {
       params: productId ? {product_id: productId} : {},
     });
+    return response.data;
+  }
+
+  /**
+   * Cancel a previously placed order. Order must belong to the profile that the API key belongs to.
+   * @param orderId - ID of the order to cancel
+   * @returns The ID of the canceled order
+   * @see https://docs.pro.coinbase.com/#cancel-an-order
+   */
+  async cancelOrder(orderId: string): Promise<string> {
+    const resource = `${OrderAPI.URL.ORDERS}/${orderId}`;
+    const response = await this.apiClient.delete(resource);
     return response.data;
   }
 


### PR DESCRIPTION
- Add ability to cancel an order using the order id.
- Updated the jsdoc comment for `cancelOpenOrders` using the verbiage from the Coinbase API docs.

Fixes #260